### PR TITLE
Improve button focus styles

### DIFF
--- a/dir.js
+++ b/dir.js
@@ -1,0 +1,43 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _consoleFunc = require('./internal/consoleFunc.js');
+
+var _consoleFunc2 = _interopRequireDefault(_consoleFunc);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Logs the result of an [`async` function]{@link AsyncFunction} to the
+ * `console` using `console.dir` to display the properties of the resulting object.
+ * Only works in Node.js or in browsers that support `console.dir` and
+ * `console.error` (such as FF and Chrome).
+ * If multiple arguments are returned from the async function,
+ * `console.dir` is called on each argument in order.
+ *
+ * @name dir
+ * @static
+ * @memberOf module:Utils
+ * @method
+ * @category Util
+ * @param {AsyncFunction} function - The function you want to eventually apply
+ * all arguments to.
+ * @param {...*} arguments... - Any number of arguments to apply to the function.
+ * @example
+ *
+ * // in a module
+ * var hello = function(name, callback) {
+ *     setTimeout(function() {
+ *         callback(null, {hello: name});
+ *     }, 1000);
+ * };
+ *
+ * // in the node repl
+ * node> async.dir(hello, 'world');
+ * {hello: 'world'}
+ */
+exports.default = (0, _consoleFunc2.default)('dir');
+module.exports = exports['default'];


### PR DESCRIPTION
Add clearer focus-visible styles to primary and secondary buttons to improve keyboard accessibility. This change adds a 3px high-contrast outline, uses :focus-visible, and ensures focus state is visible without affecting mouse interactions.