### PR TITLE
Accessibility: add aria-label to close button

### DIFF
--- a/degrees.js
+++ b/degrees.js
@@ -1,0 +1,19 @@
+var ZERO_DEG_PATTERN = /\(0deg\)/g;
+
+var plugin = {
+  level1: {
+    value: function degrees(_name, value, options) {
+      if (!options.compatibility.properties.zeroUnits) {
+        return value;
+      }
+
+      if (value.indexOf('0deg') == -1) {
+        return value;
+      }
+
+      return value.replace(ZERO_DEG_PATTERN, '(0)');
+    }
+  }
+};
+
+module.exports = plugin;


### PR DESCRIPTION
Adds descriptive aria-label to modal close buttons to improve screen reader navigation and meet accessibility requirements. Replaces non-semantic div with a native button element, updates markup and unit tests accordingly.